### PR TITLE
Fix a build error on Deep Learning AMI for Ubuntu 16.04

### DIFF
--- a/ext/dlib/depend
+++ b/ext/dlib/depend
@@ -9,7 +9,7 @@ DLIB_FUNCTIONS = \
 	cuda.inc
 OBJS += $(DLIB_OJBS)
 
-NVCC_RESULT := $(shell which nvcc 2> NULL)
+NVCC_RESULT := $(shell which nvcc 2> /dev/null)
 NVCC_TEST := $(notdir $(NVCC_RESULT))
 ifeq ($(NVCC_TEST),nvcc)
 CUDA_NVCC = nvcc

--- a/ext/dlib/depend
+++ b/ext/dlib/depend
@@ -33,7 +33,7 @@ OBJS += $(DLIB_CUDA_OBJS)
 
 .SUFFIXES: .c .m .cc .mm .cxx .cpp .o .S .cu
 .cu.o:
-	$(ECHO) compiling $@
+	$(ECHO) compiling $(<)
 	$(Q) $(CUDA_NVCC) $(CUDA_FLAGS) -c -o $@ $<
 endif
 

--- a/ext/dlib/depend
+++ b/ext/dlib/depend
@@ -13,7 +13,7 @@ NVCC_RESULT := $(shell which nvcc 2> /dev/null)
 NVCC_TEST := $(notdir $(NVCC_RESULT))
 ifeq ($(NVCC_TEST),nvcc)
 CUDA_NVCC = nvcc
-CUDA_FLAGS = $(CPPFLAGS) -I /usr/local/cuda/include -arch=sm_30 -D__STRICT_ANSI__ -D_MWAITXINTRIN_H_INCLUDED -D_FORCE_INLINES -std=c++11 -Xcompiler -fPIC -Xcompiler -funwind-tables
+CUDA_FLAGS = -DDLIB_USE_CUDA -I /usr/local/cuda/include -arch=sm_30 -D__STRICT_ANSI__ -D_MWAITXINTRIN_H_INCLUDED -D_FORCE_INLINES -std=c++11 -Xcompiler -fPIC -Xcompiler -funwind-tables
 DLIB_CUDA_SRCS = $(DLIB_SRCDIR)/dlib/dnn/curand_dlibapi.cpp \
 	$(DLIB_SRCDIR)/dlib/dnn/cudnn_dlibapi.cpp \
 	$(DLIB_SRCDIR)/dlib/dnn/cublas_dlibapi.cpp \

--- a/ext/dlib/extconf.rb
+++ b/ext/dlib/extconf.rb
@@ -25,6 +25,7 @@ $ARCH_FLAG = '-march=native'
 
 use_cuda = File.exist?('/usr/local/cuda/lib64/libcudart.so')
 if use_cuda
+  puts "Use CUDA"
   $defs << '-DDLIB_USE_CUDA'
   $CPPFLAGS << " -I/usr/local/cuda/include"
   $LIBS << " -lcudart -lcurand -lcublas -lcudnn"


### PR DESCRIPTION
I had a problem with compiling this gem while using g2.2xlarge with Deep Learning AMI for Ubuntu 16.04. I think nvcc v8 doesn't support `-Wdate-time` option, which comes from ruby package built by the distributor.

> ubuntu@ip-xxxxx:~/ruby-dlib$ ruby -rrbconfig -e 'c=RbConfig::CONFIG;c.keys.sort.each{|k|puts "#{k}: #{c[k]}"}' | grep Wdate
CPPFLAGS: -Wdate-time -D_FORTIFY_SOURCE=2

So I replaced it by simple -D option.
