### PR TITLE
Bump up version to v1.2.1

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,12 @@
 At first, you can see original Release notes.
 http://dlib.net/release_notes.html
 
+## 1.2.1 (use dlib 19.4)
+
+### Bug fixes
+
+* Fixed build issue on the latest Deep Learning AMI for Ubuntu 16.04 on AWS
+
 ## 1.2.0 (use dlib 19.4)
 
 ### New Features

--- a/lib/dlib/version.rb
+++ b/lib/dlib/version.rb
@@ -1,3 +1,3 @@
 module Dlib
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
## 1.2.0 (use dlib 19.4)
  		  
 ### Bug fixes
 
 * [Fixed build issue on the latest Deep Learning AMI for Ubuntu 16.04 on AWS](https://github.com/ruby-dlib/ruby-dlib/pull/21)
 