### PR TITLE
Fix a link error with root user installation

### DIFF
--- a/ext/dlib/depend
+++ b/ext/dlib/depend
@@ -8,13 +8,13 @@ DLIB_FUNCTIONS = \
 	dnn_detector.inc \
 	cuda.inc
 
-NVCC_RESULT := $(shell which nvcc 2> /dev/null)
-NVCC_TEST := $(notdir $(NVCC_RESULT))
-ifeq ($(NVCC_TEST),nvcc)
+# root user can't access nvcc command with relative pass because of their $PATH env
+NVCC_TEST := $(shell command -v /usr/local/cuda/bin/nvcc 2> /dev/null)
+ifdef NVCC_TEST
 
-$(info Found nvcc!)
+$(info Found nvcc! at $(NVCC_TEST))
 
-CUDA_NVCC = nvcc
+CUDA_NVCC = $(NVCC_TEST)
 CUDA_FLAGS = -DDLIB_USE_CUDA -I /usr/local/cuda/include -arch=sm_30 -D__STRICT_ANSI__ -D_MWAITXINTRIN_H_INCLUDED -D_FORCE_INLINES -std=c++11 -Xcompiler -fPIC -Xcompiler -funwind-tables
 DLIB_CUDA_SRCS = $(DLIB_SRCDIR)/dlib/dnn/curand_dlibapi.cpp \
 	$(DLIB_SRCDIR)/dlib/dnn/cudnn_dlibapi.cpp \

--- a/ext/dlib/depend
+++ b/ext/dlib/depend
@@ -12,6 +12,9 @@ OBJS += $(DLIB_OJBS)
 NVCC_RESULT := $(shell which nvcc 2> /dev/null)
 NVCC_TEST := $(notdir $(NVCC_RESULT))
 ifeq ($(NVCC_TEST),nvcc)
+
+$(info Found nvcc!)
+
 CUDA_NVCC = nvcc
 CUDA_FLAGS = -DDLIB_USE_CUDA -I /usr/local/cuda/include -arch=sm_30 -D__STRICT_ANSI__ -D_MWAITXINTRIN_H_INCLUDED -D_FORCE_INLINES -std=c++11 -Xcompiler -fPIC -Xcompiler -funwind-tables
 DLIB_CUDA_SRCS = $(DLIB_SRCDIR)/dlib/dnn/curand_dlibapi.cpp \

--- a/ext/dlib/depend
+++ b/ext/dlib/depend
@@ -7,7 +7,6 @@ DLIB_FUNCTIONS = \
 	find_candidate_object_locations.inc \
 	dnn_detector.inc \
 	cuda.inc
-OBJS += $(DLIB_OJBS)
 
 NVCC_RESULT := $(shell which nvcc 2> /dev/null)
 NVCC_TEST := $(notdir $(NVCC_RESULT))

--- a/ext/dlib/extconf.rb
+++ b/ext/dlib/extconf.rb
@@ -34,3 +34,6 @@ end
 
 have_func('rb_get_kwargs')
 create_makefile('dlib')
+
+# dry run Makefile and get debug info
+system('make -n')


### PR DESCRIPTION
AWS Deep Learning AMI doesn't have correct PATH for "nvcc" for the root user so `sudo gem install dlib` will fail to link to CUDA.